### PR TITLE
fixed incorrect constant for LED_DISPLAYTEST

### DIFF
--- a/src/LedMatrix.h
+++ b/src/LedMatrix.h
@@ -33,7 +33,7 @@
 #define LED_INTENSITY   10
 #define LED_SCAN_LIMIT  11
 #define LED_SHUTDOWN    12
-#define LED_DISPLAYTEST 16
+#define LED_DISPLAYTEST 15
 
 class LedMatrix
 {


### PR DESCRIPTION
I tried your code but failed to get the MAX7219 display to work. After some trial and error I found out that the code had an incorrect value of 16 for the display test register. This should be 15 as listed in the datasheet (page 7):

https://www.analog.com/media/en/technical-documentation/data-sheets/max7219-max7221.pdf

_Display Test  0xXF_
